### PR TITLE
Add new Exception for tracking missing Doctrine objects in Transformer

### DIFF
--- a/Doctrine/AbstractElasticaToModelTransformer.php
+++ b/Doctrine/AbstractElasticaToModelTransformer.php
@@ -2,6 +2,7 @@
 
 namespace FOS\ElasticaBundle\Doctrine;
 
+use FOS\ElasticaBundle\Exception\MissingObjectsException;
 use FOS\ElasticaBundle\HybridResult;
 use FOS\ElasticaBundle\Transformer\ElasticaToModelTransformerInterface;
 use FOS\ElasticaBundle\Transformer\HighlightableModelInterface;
@@ -84,7 +85,7 @@ abstract class AbstractElasticaToModelTransformer implements ElasticaToModelTran
      * model objects fetched from the doctrine repository
      *
      * @param array $elasticaObjects of elastica objects
-     * @throws \RuntimeException
+     * @throws MissingObjectsException
      * @return array
      **/
     public function transform(array $elasticaObjects)
@@ -97,7 +98,7 @@ abstract class AbstractElasticaToModelTransformer implements ElasticaToModelTran
 
         $objects = $this->findByIdentifiers($ids, $this->options['hydrate']);
         if (!$this->options['ignore_missing'] && count($objects) < count($elasticaObjects)) {
-            throw new \RuntimeException('Cannot find corresponding Doctrine objects for all Elastica results.');
+            throw new MissingObjectsException('Cannot find corresponding Doctrine objects for all Elastica results.', $ids);
         };
 
         foreach ($objects as $object) {

--- a/Exception/MissingObjectsException.php
+++ b/Exception/MissingObjectsException.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace FOS\ElasticaBundle\Exception;
+
+class MissingObjectsException extends \RuntimeException
+{
+    /**
+     * @var array
+     */
+    protected $expectedIds;
+
+    /**
+     * @param string $message The exception message
+     * @param array $expectedIds The array of identifiers which could not be fetched
+     */
+    public function __construct($message, array $expectedIds)
+    {
+        parent::__construct($message);
+        $this->expectedIds = $expectedIds;
+    }
+
+    /**
+     * Get the identifiers which could not be fetched
+     *
+     * @return array
+     */
+    public function getExpectedIds()
+    {
+        return $this->expectedIds;
+    }
+}

--- a/Tests/Doctrine/AbstractElasticaToModelTransformerTest.php
+++ b/Tests/Doctrine/AbstractElasticaToModelTransformerTest.php
@@ -4,6 +4,7 @@ namespace FOS\ElasticaBundle\Tests\Doctrine;
 
 use Elastica\Result;
 use FOS\ElasticaBundle\Doctrine\ORM\ElasticaToModelTransformer;
+use FOS\ElasticaBundle\Exception\MissingObjectsException;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 
 class AbstractElasticaToModelTransformerTest extends \PHPUnit_Framework_TestCase
@@ -51,6 +52,40 @@ class AbstractElasticaToModelTransformerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($firstElasticaResult, $hybridResults[0]->getResult());
         $this->assertEquals($secondOrmResult, $hybridResults[1]->getTransformed());
         $this->assertEquals($thirdElasticaResult, $hybridResults[1]->getResult());
+    }
+
+    /**
+     * Test that missing Doctrine objects throws a MissingObjectsException
+     */
+    public function testMissingThrowsException()
+    {
+        $transformer = $this->getMock(
+            'FOS\ElasticaBundle\Doctrine\ORM\ElasticaToModelTransformer',
+            array('findByIdentifiers'),
+            array($this->registry, $this->objectClass, array('ignore_missing' => false))
+        );
+
+        $transformer->setPropertyAccessor(PropertyAccess::createPropertyAccessor());
+        $transformer->expects($this->once())
+            ->method('findByIdentifiers')
+            ->with(array(1, 2, 3))
+            ->willReturn(array());
+
+        $firstElasticaResult = new Result(array('_id' => 1));
+        $secondElasticaResult = new Result(array('_id' => 2));
+        $thirdElasticaResult = new Result(array('_id' => 3));
+
+        try {
+            $transformer->transform(array($firstElasticaResult, $secondElasticaResult, $thirdElasticaResult));
+        } catch (MissingObjectsException $ex) {
+            // Not using expectedException so we can assert the publically accessible exception state
+            $this->assertInstanceOf('FOS\ElasticaBundle\Exception\MissingObjectsException', $ex);
+            $this->assertEquals('Cannot find corresponding Doctrine objects for all Elastica results.', $ex->getMessage());
+            $this->assertEquals(array(1, 2, 3), $ex->getExpectedIds());
+            return;
+        }
+
+        $this->fail('Expected MissingObjectsException has not been thrown');
     }
 
     protected function setUp()


### PR DESCRIPTION
This adds a new Exception for tracking when the Doctrine Transformer fails to locate corresponding entities in the database. 

Having this information (specifically what IDs were searched for) is useful as it can be used for a background fixup or alerting developers to a leak in the entity transformation between ES and Doctrine. This should be backwards compatible, as it extends the Exception that was originally thrown, as well as not changing the message.
